### PR TITLE
Added force option for static content deploy

### DIFF
--- a/guides/v2.2/comp-mgr/install-extensions/b2b-installation.md
+++ b/guides/v2.2/comp-mgr/install-extensions/b2b-installation.md
@@ -30,7 +30,7 @@ The {{site.data.var.b2b}} extension is only available for {{site.data.var.ee}} v
 
     bin/magento setup:di:compile
 
-    bin/magento setup:static-content:deploy
+    bin/magento setup:static-content:deploy -f
     ```
 
 <div class="bs-callout bs-callout-info" markdown="1">


### PR DESCRIPTION
The static content deploy throws an exception if executed without the force (-f) option in default/developer mode for version 2.2.0 and above, hence added the force option.